### PR TITLE
Active color should be white for design purpose

### DIFF
--- a/src/variables.less
+++ b/src/variables.less
@@ -94,7 +94,7 @@
 
 @dropdownLinkColor:             @grayDark;
 @dropdownLinkColorHover:        @white;
-@dropdownLinkColorActive:       @dropdownLinkColor;
+@dropdownLinkColorActive:       @white;
 
 @dropdownLinkBackgroundActive:  @linkColor;
 @dropdownLinkBackgroundHover:   @dropdownLinkBackgroundActive;


### PR DESCRIPTION
The active color is currently grayDark. Since the selection is blue a white active option would match the hover and create a constrast that will improve the text readability.
